### PR TITLE
feat: removed address control from commandHandler

### DIFF
--- a/contracts/EmailRecoveryCommandHandler.sol
+++ b/contracts/EmailRecoveryCommandHandler.sol
@@ -131,10 +131,6 @@ contract EmailRecoveryCommandHandler is IEmailRecoveryCommandHandler {
             revert InvalidAccount();
         }
 
-        if (recoveryModuleInEmail != address(this)) {
-            revert InvalidRecoveryModule();
-        }
-
         return accountInEmail;
     }
 

--- a/contracts/EmailRecoveryCommandHandler.sol
+++ b/contracts/EmailRecoveryCommandHandler.sol
@@ -12,7 +12,6 @@ import {StringUtils} from "@zk-email/email-recovery/src/libraries/StringUtils.so
 contract EmailRecoveryCommandHandler is IEmailRecoveryCommandHandler {
     error InvalidCommandParams();
     error InvalidAccount();
-    error InvalidRecoveryModule();
 
     /**
      * @notice Returns a hard-coded two-dimensional array of strings representing the command


### PR DESCRIPTION
# WHAT

Removed address control from commandHandler because recovery module address and commandHandler address are not same.
